### PR TITLE
fix(visualizer): replace functools.cache with lru_cache for Python 3.8 compatibility

### DIFF
--- a/signwriting/visualizer/visualize.py
+++ b/signwriting/visualizer/visualize.py
@@ -1,5 +1,5 @@
 import os
-from functools import cache
+from functools import lru_cache
 from pathlib import Path
 from typing import Tuple, List, Literal, Union
 
@@ -14,13 +14,13 @@ from signwriting.formats.swu_to_fsw import swu2fsw
 RGBA = Tuple[int, int, int, int]
 
 
-@cache
+@lru_cache(maxsize=None)
 def get_font(font_name: str) -> ImageFont.FreeTypeFont:
     font_path = Path(__file__).parent / f'{font_name}.ttf'
     return ImageFont.truetype(str(font_path), 30)
 
 
-@cache
+@lru_cache(maxsize=None)
 def get_symbol_size(symbol: str):
     font = get_font('SuttonSignWritingLine')
     line_id = symbol_line(key2id(symbol))


### PR DESCRIPTION
## Summary

- `functools.cache` was introduced in Python 3.9 and causes an `ImportError` on Python 3.8
- Replace `from functools import cache` with `from functools import lru_cache`
- Replace `@cache` with `@lru_cache(maxsize=None)` — these are exactly equivalent, but `lru_cache` is available from Python 3.2+

## Test plan

- [ ] Verify the module imports without error on Python 3.8
- [ ] Verify existing tests pass (caching behaviour is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)