### PR TITLE
Add optional seed for deterministic fingerspelling

### DIFF
--- a/signwriting/fingerspelling/fingerspelling.py
+++ b/signwriting/fingerspelling/fingerspelling.py
@@ -31,6 +31,7 @@ def variant_signs(char_variants: CharVariants, variants: List[str] = None) -> Li
 
 
 def spell(word: str, language=None, chars=None, vertical=True, variants=None, seed=None, rng=None) -> Union[str, None]:
+    # pylint: disable=too-many-arguments
     if chars is None:
         if language is None:
             raise ValueError("Either language or chars must be provided")

--- a/signwriting/fingerspelling/fingerspelling.py
+++ b/signwriting/fingerspelling/fingerspelling.py
@@ -30,11 +30,14 @@ def variant_signs(char_variants: CharVariants, variants: List[str] = None) -> Li
     return char_variants
 
 
-def spell(word: str, language=None, chars=None, vertical=True, variants=None) -> Union[str, None]:
+def spell(word: str, language=None, chars=None, vertical=True, variants=None, seed=None, rng=None) -> Union[str, None]:
     if chars is None:
         if language is None:
             raise ValueError("Either language or chars must be provided")
         chars = get_chars(language)
+
+    if rng is None:
+        rng = random.Random(seed) if seed is not None else random
 
     sl = []
     caret = 0
@@ -42,7 +45,9 @@ def spell(word: str, language=None, chars=None, vertical=True, variants=None) ->
         found = False
         for c, options in chars.items():
             if word[caret:caret + len(c)].lower() == c:
-                sl.append(random.choice(variant_signs(options, variants)))
+                signs = variant_signs(options, variants)
+                # Only draw from the rng when there is an actual choice to make.
+                sl.append(signs[0] if len(signs) == 1 else rng.choice(signs))
                 caret += len(c)
                 found = True
                 break
@@ -57,8 +62,10 @@ def tokenize(text: str) -> List[str]:
     return re.findall(r'[^\W_]+|[^\w\s]|_', text)
 
 
-def spell_text(text: str, language=None, vertical=True, variants=None) -> Union[str, None]:
-    spellings = [spell(token, language=language, vertical=vertical, variants=variants)
+def spell_text(text: str, language=None, vertical=True, variants=None, seed=None) -> Union[str, None]:
+    # Share a single seeded rng across tokens so the whole text spells deterministically.
+    rng = random.Random(seed) if seed is not None else None
+    spellings = [spell(token, language=language, vertical=vertical, variants=variants, rng=rng)
                  for token in tokenize(text)]
     if any(spelling is None for spelling in spellings):
         return None

--- a/signwriting/fingerspelling/test_fingerspelling.py
+++ b/signwriting/fingerspelling/test_fingerspelling.py
@@ -48,6 +48,32 @@ class FingerspellingCase(unittest.TestCase):
         # the 1-hand "+" glyph is identical to the "t" glyph
         self.assertEqual(one_hand, spell("t", language='en-us-ase-asl'))
 
+    def test_spell_seed_is_deterministic(self):
+        # "w" has multiple default options, so the choice is seed-dependent.
+        first = spell("www", language='en-us-ase-asl', seed=42)
+        second = spell("www", language='en-us-ase-asl', seed=42)
+        self.assertEqual(first, second)
+
+    def test_spell_text_seed_is_deterministic(self):
+        first = spell_text("world wide web", language='en-us-ase-asl', seed=42)
+        second = spell_text("world wide web", language='en-us-ase-asl', seed=42)
+        self.assertEqual(first, second)
+
+    def test_spell_text_different_seeds_can_differ(self):
+        # With several multi-option characters the two seeds should diverge.
+        text = "www kkk ppp vvv"
+        self.assertNotEqual(
+            spell_text(text, language='en-us-ase-asl', seed=1),
+            spell_text(text, language='en-us-ase-asl', seed=2),
+        )
+
+    def test_spell_seed_independent_for_single_option_chars(self):
+        # "abc" has one option per character, so the seed must not affect the result.
+        self.assertEqual(
+            spell("abc", language='en-us-ase-asl', seed=1),
+            spell("abc", language='en-us-ase-asl', seed=2),
+        )
+
     def test_tokenize_splits_words_and_symbols(self):
         self.assertEqual(tokenize("google.com/test+ai"),
                          ["google", ".", "com", "/", "test", "+", "ai"])


### PR DESCRIPTION
## Summary

`spell` / `spell_text` pick character glyph variants with `random.choice` on the global `random` module, so spelling the same text twice can produce different SignWriting and there is no way to make output reproducible without globally seeding `random` (which is intrusive for callers).

This PR adds an optional `seed`:

- `spell(..., seed=None, rng=None)` — resolves an RNG: an explicit `rng` if provided, else `random.Random(seed)` when a seed is given, else the global `random` module (unchanged default).
- `spell_text(..., seed=None)` — builds a single seeded `random.Random` and threads it through every token's `spell` call, so the whole text spells deterministically from one seed.
- The RNG is only drawn when a character actually has more than one option (`signs[0] if len(signs) == 1 else rng.choice(signs)`), so single-option characters are unaffected by the seed and never consume the stream needlessly.

Backward compatible: with no seed, behavior is identical to before (uses the global `random`).

## Tests

Existing tests pass unchanged. Added coverage for:
- same seed → identical spelling (`spell` and `spell_text`)
- different seeds can diverge
- seed has no effect for single-option characters

```
Ran 16 tests in 0.003s
OK
```