### PR TITLE
Optimize FSW parsing

### DIFF
--- a/signwriting/formats/fsw_to_sign.py
+++ b/signwriting/formats/fsw_to_sign.py
@@ -3,21 +3,28 @@ import re
 from signwriting.types import Sign
 
 
-def fsw_to_sign(fsw: str) -> Sign:
-    boxes = re.finditer(r'([BLMR])(\d{3})x(\d{3})', fsw)
-    box = next(boxes, None)
-    # pylint: disable=invalid-name
-    box_symbol, x, y = box.groups() if box is not None else ("M", 500, 500)
+BOX_RE = re.compile(r"([BLMR])(\d{3})x(\d{3})")
+SYMBOL_RE = re.compile(r"(S[123][0-9a-f]{2}[0-5][0-9a-f])(\d{3})x(\d{3})")
 
-    symbols = re.findall(r'(S[123][0-9a-f]{2}[0-5][0-9a-f])(\d{3})x(\d{3})', fsw)
+
+def fsw_to_sign(fsw: str) -> Sign:
+    box = BOX_RE.search(fsw)
+    if box is None:
+        box_symbol = "M"
+        box_position = (500, 500)
+    else:
+        box_symbol = box[1]
+        box_position = (int(box[2]), int(box[3]))
+
+    symbols = SYMBOL_RE.findall(fsw)
 
     return {
         "box": {
             "symbol": box_symbol,
-            "position": (int(x), int(y))
+            "position": box_position,
         },
         "symbols": [{
-            "symbol": s[0],
-            "position": (int(s[1]), int(s[2]))
-        } for s in symbols]
+            "symbol": symbol,
+            "position": (int(x), int(y)),
+        } for symbol, x, y in symbols],
     }

--- a/signwriting/formats/test_fsw_to_sign.py
+++ b/signwriting/formats/test_fsw_to_sign.py
@@ -1,7 +1,27 @@
+import re
 import unittest
 
 from signwriting.formats.fsw_to_sign import fsw_to_sign
 from signwriting.formats.fsw_to_swu import fsw2swu
+
+
+def legacy_fsw_to_sign(fsw):
+    boxes = re.finditer(r'([BLMR])(\d{3})x(\d{3})', fsw)
+    box = next(boxes, None)
+    box_symbol, x, y = box.groups() if box is not None else ("M", 500, 500)
+
+    symbols = re.findall(r'(S[123][0-9a-f]{2}[0-5][0-9a-f])(\d{3})x(\d{3})', fsw)
+
+    return {
+        "box": {
+            "symbol": box_symbol,
+            "position": (int(x), int(y)),
+        },
+        "symbols": [{
+            "symbol": s[0],
+            "position": (int(s[1]), int(s[2])),
+        } for s in symbols],
+    }
 
 
 class ParseSignCase(unittest.TestCase):
@@ -16,6 +36,19 @@ class ParseSignCase(unittest.TestCase):
         fsw = 'AS10011S10019S2e704S2e748M525x535S2e748483x510S10011501x466S2e704510x500S10019476x475'
         swu = fsw2swu(fsw)
         self.assertEqual(swu, '𝠀񀀒񀀚񋚥񋛩𝠃𝤟𝤩񋛩𝣵𝤐񀀒𝤇𝣤񋚥𝤐𝤆񀀚𝣮𝣭')
+
+    def test_matches_legacy_parser(self):
+        cases = [
+            '',
+            'S10000493x489',
+            'M123x456S1f720487x492',
+            'AS10011S10019S2e704S2e748M525x535S2e748483x510S10011501x466S2e704510x500S10019476x475',
+            'M530x538S37602508x462S15a11493x494S20e00488x510S22f03469x517',
+            'M<s><s>M<s>p483',
+        ]
+        for fsw in cases:
+            with self.subTest(fsw=fsw):
+                self.assertEqual(fsw_to_sign(fsw), legacy_fsw_to_sign(fsw))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Replace repeated FSW parser regex calls with module-level compiled regexes.
- Keep the public `fsw_to_sign` API unchanged.
- Add a parity test against the previous parser logic across normal, empty, symbol-only, malformed, and multi-symbol FSW strings.

## Validation
- `/home/shaltiel/tmp/.venv/bin/python -m unittest signwriting.formats.test_fsw_to_sign`
- `/home/shaltiel/tmp/.venv/bin/python -m unittest discover signwriting`

## Local Benchmark
Sampled 250,000 parses across representative FSW strings:
- previous parser: 752,603 parses/sec
- optimized parser: 1,094,049 parses/sec
- improvement: ~1.45x
