### PR TITLE
Fix 415 on documented GET URLs for /fingerspelling and /visualizer

### DIFF
--- a/signwriting/fingerspelling/server.py
+++ b/signwriting/fingerspelling/server.py
@@ -4,8 +4,8 @@ from flask_restful import Resource, reqparse
 from signwriting.fingerspelling.fingerspelling import spell, get_chars
 
 parser = reqparse.RequestParser()
-parser.add_argument('text', type=str, required=True, help='Text to fingerspell')
-parser.add_argument('signed_language', type=str, required=True, help='Signed language ISO-3 code')
+parser.add_argument('text', type=str, location='args', required=True, help='Text to fingerspell')
+parser.add_argument('signed_language', type=str, location='args', required=True, help='Signed language ISO-3 code')
 
 
 class Fingerspelling(Resource):

--- a/signwriting/visualizer/server.py
+++ b/signwriting/visualizer/server.py
@@ -23,8 +23,10 @@ def send_pil_image(pil_img):
 
 
 parser = reqparse.RequestParser()
-parser.add_argument('fsw', type=str, location='args', required=False, help='FSW String (Must be provided if swu is not provided)')
-parser.add_argument('swu', type=str, location='args', required=False, help='SWU String (Must be provided if fsw is not provided)')
+parser.add_argument('fsw', type=str, location='args', required=False,
+                    help='FSW String (Must be provided if swu is not provided)')
+parser.add_argument('swu', type=str, location='args', required=False,
+                    help='SWU String (Must be provided if fsw is not provided)')
 parser.add_argument('line', type=str, location='args', default='000000ff', help='Line color in hex format')
 parser.add_argument('fill', type=str, location='args', default='ffffffff', help='Fill color in hex format')
 

--- a/signwriting/visualizer/server.py
+++ b/signwriting/visualizer/server.py
@@ -23,10 +23,10 @@ def send_pil_image(pil_img):
 
 
 parser = reqparse.RequestParser()
-parser.add_argument('fsw', type=str, required=False, help='FSW String (Must be provided if swu is not provided)')
-parser.add_argument('swu', type=str, required=False, help='SWU String (Must be provided if fsw is not provided)')
-parser.add_argument('line', type=str, default='000000ff', help='Line color in hex format')
-parser.add_argument('fill', type=str, default='ffffffff', help='Fill color in hex format')
+parser.add_argument('fsw', type=str, location='args', required=False, help='FSW String (Must be provided if swu is not provided)')
+parser.add_argument('swu', type=str, location='args', required=False, help='SWU String (Must be provided if fsw is not provided)')
+parser.add_argument('line', type=str, location='args', default='000000ff', help='Line color in hex format')
+parser.add_argument('fill', type=str, location='args', default='ffffffff', help='Fill color in hex format')
 
 
 class Visualizer(Resource):


### PR DESCRIPTION
## Summary

The README documents query-string GETs for all three server endpoints, but only `/mouthing` worked that way. `/fingerspelling` and `/visualizer` returned **415: "Did not attempt to load JSON data..."** for the exact URLs the README shows (e.g. https://signwriting.nagish.io/fingerspelling?text=hello&signed_language=en-us-ase-asl).

Cause: their `reqparse` arguments didn't specify `location='args'`, so flask-restful defaulted to parsing the JSON body, and Flask aborts with 415 when a request has no `Content-Type: application/json`. The mouthing parser already had `location='args'` — this brings the other two in line.

## Verification

Built the Docker image and tested the README's documented URLs:
- `/fingerspelling?text=hello&signed_language=en-us-ase-asl` → 200 with FSW
- `/visualizer?fsw=...` → 200 `image/png` (also with `line`/`fill` color params)
- `/mouthing` — unchanged
- Missing required params now return a proper 400 with the help message (previously 415)

All 105 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)