### PR TITLE
feat(utils): add canonicalize utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ result_sign = join_signs_vertical(char_a, char_b)
 # M510x518S1f720490x481S14720496x496
 ```
 
+2. `canonicalize` rewrites a sign's symbols in a canonical order (by category,
+   then top-to-bottom, left-to-right) and tightens its box, without changing
+   the rendered image. See [`utils/canonicalize`](signwriting/utils/canonicalize/README.md).
+
+```python
+from signwriting.utils.canonicalize import canonicalize
+
+canonicalize('M521x547S20310506x500S33100482x443')
+# M521x515S33100482x443S20310506x500
+```
+
 
 ### `signwriting.fingerspelling`
 

--- a/signwriting/utils/canonicalize/README.md
+++ b/signwriting/utils/canonicalize/README.md
@@ -1,0 +1,79 @@
+# canonicalize
+
+Rewrite a single SignWriting sign so its symbols are listed in a canonical
+order and its box fits tightly.
+
+```python
+from signwriting.utils.canonicalize import canonicalize
+
+canonicalize("M521x547S20310506x500S33100482x443")
+# "M521x515S33100482x443S20310506x500"
+```
+
+`canonicalize` accepts ASCII **Formal SignWriting (FSW)**. For SWU input,
+convert first via `signwriting.formats.swu_to_fsw.swu2fsw`.
+
+## Algorithm
+
+1. **Order by category.** Each symbol belongs to one ISWA category, sorted in
+   the order below. Within a category, symbols are written top-to-bottom, then
+   left-to-right.
+
+   | Rank | Category  | Base range  |
+   | ---- | --------- | ----------- |
+   | 0    | faces     | `S2ff-S36c` |
+   | 1    | other     | `S36d+`     |
+   | 2    | hands     | `S100-S204` |
+   | 3    | contact   | `S205-S220` |
+   | 4    | movement  | `S221-S2fe` |
+
+   This order was derived empirically: across the `single_signs` corpus, for
+   every pair of categories the dominant writing order is faces → other →
+   hands → contact → movement (e.g. faces precede hands 69% of the time,
+   hands precede movement 78%).
+
+2. **Keep an overlap only when its draw order is visible.** When two glyphs
+   share an inked pixel, one is drawn on top of the other - but that only
+   affects the image if the two paint a shared pixel with *different* colors
+   (e.g. a hand's opaque white fill covering a face's line). So each
+   overlapping pair is rendered both ways: if the images match, the order is
+   free and the pair sorts into canonical order; if they differ, the pair keeps
+   its input order. (Glyphs whose ink is disjoint trivially commute and are
+   never rendered.) These order-sensitive pairs become hard precedence
+   constraints, and the canonical order is produced by a topological sort that
+   honours them while otherwise following the category order above.
+
+3. **Tighten the box.** The box's bottom-right corner is recomputed from the
+   symbols' rendered sizes (the same calculation `signwriting_to_image`
+   performs with `trust_box=False`, exposed as
+   `signwriting.visualizer.visualize.signwriting_box`). The box marker
+   (`M`/`L`/`R`/`B`) is preserved.
+
+`canonicalize` is idempotent, and `render(canonicalize(sign))` is
+pixel-identical to `render(sign)` (with the same box), because two symbols are
+only ever reordered when swapping their draw order leaves the image unchanged.
+
+## Caveats
+
+* Overlap detection relies on the `SuttonSignWriting` fonts being available
+  (loaded via `signwriting.visualizer.visualize`).
+* Overlap and the both-ways render comparison use crisp 1-bit glyph masks.
+  Antialiased rendering can blend glyph fringes that the 1-bit masks treat as
+  disjoint, so the render-equivalence guarantee holds for non-antialiased
+  rendering.
+
+## Examples
+
+Real signs from the `single_signs` corpus, one per kind of fix. Images are
+rendered live by
+[signbank.org's glyphogram](https://www.signbank.org/signpuddle2.0/glyphogram.php),
+which trusts the box in the FSW (so a wrong box shows up as clipping or
+padding).
+
+| Fix | Source | Target |
+| --- | --- | --- |
+| **Box too small.** The downward arrow (`S21b00` at y=582) falls below the stated box (`550`), so it renders clipped. The symbols are already in canonical order; only the box is tightened to `591`. | `M521x550S36d00479x450S1001c494x520S21b00500x582` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M521x550S36d00479x450S1001c494x520S21b00500x582&pad=10&size=2) | `M521x591S36d00479x450S1001c494x520S21b00500x582` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M521x591S36d00479x450S1001c494x520S21b00500x582&pad=10&size=2) |
+| **Order fixed, no overlap.** The face (`S32400`) is written after the hand (`S18500`), but faces come first. They don't overlap, so the face moves to the front; the image is unchanged. | `M563x553S18500536x495S32400482x483S29900549x521` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M563x553S18500536x495S32400482x483S29900549x521&pad=10&size=2) | `M563x553S32400482x483S18500536x495S29900549x521` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M563x553S32400482x483S18500536x495S29900549x521&pad=10&size=2) |
+| **Order fixed despite overlap.** The face (`S33100`) overlaps the hand (`S11511`), but the hand has no fill there, so rendering both orders is identical - the face can safely move to the front. | `M544x527S11511503x500S33100482x482S20600522x495` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M544x527S11511503x500S33100482x482S20600522x495&pad=10&size=2) | `M544x527S33100482x482S11511503x500S20600522x495` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M544x527S33100482x482S11511503x500S20600522x495&pad=10&size=2) |
+| **Order fixed despite overlap.** The eyebrow (`S30a00`) overlaps the hand (`S10000`), but again neither covers the other, so the rendered image is unaffected and the face is written first. | `M518x529S10000469x499S30a00482x482` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M518x529S10000469x499S30a00482x482&pad=10&size=2) | `M518x529S30a00482x482S10000469x499` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M518x529S30a00482x482S10000469x499&pad=10&size=2) |
+| **Order can't be fixed.** Two hands (`S10010`, `S15d59`) overlap, and the right one's opaque white fill covers the left one's lines - rendering the two orders gives different images, so the input order is kept. We'd normally write the top-left hand (`S15d59`) first, but here it has to come second. | `M515x516S10010500x486S15d59485x484` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M515x516S10010500x486S15d59485x484&pad=10&size=2) | `M515x516S10010500x486S15d59485x484` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M515x516S10010500x486S15d59485x484&pad=10&size=2) |

--- a/signwriting/utils/canonicalize/__init__.py
+++ b/signwriting/utils/canonicalize/__init__.py
@@ -1,0 +1,3 @@
+from signwriting.utils.canonicalize.canonicalize import canonicalize
+
+__all__ = ["canonicalize"]

--- a/signwriting/utils/canonicalize/canonicalize.py
+++ b/signwriting/utils/canonicalize/canonicalize.py
@@ -1,0 +1,167 @@
+"""Rewrite a single FSW sign with its symbols in a canonical order.
+
+Symbols are sorted by ISWA category, then top-to-bottom and left-to-right
+within a category. The category order (faces first, movement last) was
+derived empirically from the single_signs corpus - see README.md.
+
+The one wrinkle is overlapping glyphs. When two symbols' inked pixels
+overlap, one is drawn on top of the other - but that only matters if the
+two paint a shared pixel with different colors (e.g. one symbol's opaque
+white fill covering the other's line). So overlapping pairs are rendered
+both ways: if the images match, the order is free and we reorder to
+canonical; if they differ, the pair keeps its input order. The sort is
+therefore a topological one - the canonical order is the target, with
+order-sensitive overlaps as hard precedence constraints layered on top.
+
+Finally, the sign's box is recomputed to tightly fit the symbols (the same
+calculation ``signwriting_to_image`` performs when ``trust_box`` is off).
+"""
+import functools
+from typing import List
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+from signwriting.formats.fsw_to_sign import fsw_to_sign
+from signwriting.formats.fsw_to_swu import key2id, symbol_fill, symbol_line
+from signwriting.formats.sign_to_fsw import sign_to_fsw
+from signwriting.types import Sign, SignSymbol
+from signwriting.visualizer.visualize import get_font, get_symbol_size, signwriting_box
+
+
+def _category_rank(symbol: str) -> int:
+    base = int(symbol[1:4], 16)
+    if 0x2ff <= base <= 0x36c:  # faces
+        return 0
+    if base >= 0x36d:  # other: head, trunk, limbs, location, punctuation
+        return 1
+    if base <= 0x204:  # hands
+        return 2
+    if base <= 0x220:  # contact
+        return 3
+    return 4  # movement (0x221-0x2fe)
+
+
+def _sort_key(symbol: SignSymbol):
+    x, y = symbol["position"]
+    return _category_rank(symbol["symbol"]), y, x
+
+
+@functools.cache
+def _symbol_mask(symbol: str) -> np.ndarray:
+    """Boolean ink mask (line + fill) of a symbol rendered at the origin."""
+    width, height = get_symbol_size(symbol)
+    image = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(image)
+    draw.fontmode = "1"  # 1-bit edges; overlap is a crisp yes/no question
+    symbol_id = key2id(symbol)
+    draw.text((0, 0), symbol_fill(symbol_id), fill=(0, 0, 0, 255), font=get_font("SuttonSignWritingFill"))
+    draw.text((0, 0), symbol_line(symbol_id), fill=(0, 0, 0, 255), font=get_font("SuttonSignWritingLine"))
+    return np.asarray(image)[:, :, 3] > 0
+
+
+def _symbols_share_ink(a: SignSymbol, b: SignSymbol) -> bool:
+    """True if two positioned symbols share an inked pixel (a real glyph
+    overlap, not merely intersecting bounding boxes)."""
+    (ax, ay), (bx, by) = a["position"], b["position"]
+    mask_a = _symbol_mask(a["symbol"])
+    mask_b = _symbol_mask(b["symbol"])
+
+    left, top = max(ax, bx), max(ay, by)
+    right = min(ax + mask_a.shape[1], bx + mask_b.shape[1])
+    bottom = min(ay + mask_a.shape[0], by + mask_b.shape[0])
+    if left >= right or top >= bottom:
+        return False
+
+    region_a = mask_a[top - ay:bottom - ay, left - ax:right - ax]
+    region_b = mask_b[top - by:bottom - by, left - bx:right - bx]
+    return bool(np.logical_and(region_a, region_b).any())
+
+
+@functools.cache
+def _draw_order_differs(symbol_a: str, symbol_b: str, dx: int, dy: int) -> bool:
+    """True if drawing ``symbol_a`` then ``symbol_b`` differs from the reverse,
+    with ``symbol_b`` offset from ``symbol_a`` by ``(dx, dy)``. Order only shows
+    when the glyphs paint a shared pixel with different colors - e.g. one
+    symbol's opaque white fill covering the other's line."""
+    a_width, a_height = get_symbol_size(symbol_a)
+    b_width, b_height = get_symbol_size(symbol_b)
+    min_x, min_y = min(0, dx), min(0, dy)
+    size = (max(a_width, dx + b_width) - min_x, max(a_height, dy + b_height) - min_y)
+
+    def render(symbols) -> np.ndarray:
+        image = Image.new("RGBA", size, (255, 255, 255, 0))
+        draw = ImageDraw.Draw(image, "RGBA")
+        draw.fontmode = "1"  # match the non-antialiased render-equivalence guarantee
+        for symbol, (x, y) in symbols:
+            symbol_id = key2id(symbol)
+            draw.text((x, y), symbol_fill(symbol_id), fill=(255, 255, 255, 255), font=get_font("SuttonSignWritingFill"))
+            draw.text((x, y), symbol_line(symbol_id), fill=(0, 0, 0, 255), font=get_font("SuttonSignWritingLine"))
+        return np.asarray(image)
+
+    a_at = (symbol_a, (-min_x, -min_y))
+    b_at = (symbol_b, (dx - min_x, dy - min_y))
+    return not np.array_equal(render([a_at, b_at]), render([b_at, a_at]))
+
+
+def _order_matters(a: SignSymbol, b: SignSymbol) -> bool:
+    """True if the draw order of two symbols affects the rendered image.
+
+    Glyphs that don't share ink commute trivially; glyphs that do are rendered
+    both ways and only constrain the order when the two images differ."""
+    if not _symbols_share_ink(a, b):
+        return False
+    (ax, ay), (bx, by) = a["position"], b["position"]
+    return _draw_order_differs(a["symbol"], b["symbol"], bx - ax, by - ay)
+
+
+def _canonical_order(symbols: List[SignSymbol]) -> List[SignSymbol]:
+    n = len(symbols)
+    # Symbols whose draw order is visible must keep their input order: edge
+    # i -> j whenever i precedes j in the input and swapping them would change
+    # the image. Edges only ever point forward in the input, so it's acyclic.
+    successors = [[] for _ in range(n)]
+    indegree = [0] * n
+    for i in range(n):
+        for j in range(i + 1, n):
+            if _order_matters(symbols[i], symbols[j]):
+                successors[i].append(j)
+                indegree[j] += 1
+
+    keys = [_sort_key(s) for s in symbols]
+    placed = [False] * n
+    order = []
+    for _ in range(n):
+        # Among symbols whose overlap-predecessors are all placed, take the one
+        # earliest in canonical order (input index breaks ties for stability).
+        ready = (i for i in range(n) if not placed[i] and indegree[i] == 0)
+        chosen = min(ready, key=lambda i: (keys[i], i))
+        placed[chosen] = True
+        order.append(symbols[chosen])
+        for j in successors[chosen]:
+            indegree[j] -= 1
+    return order
+
+
+def canonicalize(fsw: str) -> str:
+    """Rewrite an FSW sign with its symbols in canonical order and a tight box.
+
+    Symbols are ordered by category (faces, other, hands, contact, movement)
+    and within a category top-to-bottom then left-to-right; overlapping symbols
+    keep their original relative order so the rendered image is unchanged.
+
+    ``fsw`` must be ASCII Formal SignWriting. For SWU input, convert with
+    ``signwriting.formats.swu_to_fsw.swu2fsw`` first.
+    """
+    if not fsw.isascii():
+        raise ValueError("canonicalize expects ASCII FSW; convert SWU input via swu2fsw first")
+
+    sign = fsw_to_sign(fsw)
+    if not sign["symbols"]:
+        return fsw
+
+    canonical_sign: Sign = {
+        "box": {"symbol": sign["box"]["symbol"], "position": signwriting_box(sign)},
+        "symbols": _canonical_order(sign["symbols"]),
+    }
+    return sign_to_fsw(canonical_sign)

--- a/signwriting/utils/canonicalize/test_canonicalize.py
+++ b/signwriting/utils/canonicalize/test_canonicalize.py
@@ -1,0 +1,153 @@
+import unittest
+
+import numpy as np
+
+from signwriting.formats.fsw_to_sign import fsw_to_sign
+from signwriting.utils.canonicalize import canonicalize
+from signwriting.utils.canonicalize.canonicalize import _order_matters, _symbols_share_ink
+from signwriting.visualizer.visualize import signwriting_to_image
+
+# Real signs from the single_signs corpus, spanning a range of symbol counts
+# and categories. Canonicalization must never change the rendered image.
+CORPUS_SIGNS = [
+    "M534x515S14420491x484S10020519x485S14420465x484",
+    "M518x574S34400482x483S20300494x526S26c06496x547",
+    "M517x539S15d2a483x460S19c50483x500S2f900492x534S26a14490x483S2f700498x473",
+    "M566x520S36d00479x480S20500477x486S20500489x486S27100526x502S14c56492x496",
+    "M524x520S15a11501x497S15a19476x497S20600487x479",
+    "M535x530S30004482x483S15d10495x464S26504521x495S15d10494x503S20500509x507",
+    "M538x523S1ea50514x478S1ea58462x479S26904522x503S26914462x505",
+    "M511x527S1f902492x474S2e309488x504",
+    "M530x514S15d48469x487S11552500x497S20600492x487",
+    "M538x531S36500482x483S20500495x495S1ea10515x510S26507523x493",
+    "M598x558S2f800490x441S2f801431x450S2f800454x441S2f800526x441S2f801410x473"
+    "S2f802402x491S2f803412x527S2f804437x547S2f804473x547S2f804510x547S2f805547x522"
+    "S2f805566x497S2f806587x461S2f800549x450",
+    # Overlapping pairs: the first two reorder (harmless overlap), the last
+    # keeps order (the right hand's fill covers the left hand's lines).
+    "M544x527S11511503x500S33100482x482S20600522x495",
+    "M518x529S10000469x499S30a00482x482",
+    "M515x516S10010500x486S15d59485x484",
+]
+
+
+class CanonicalizeOverlapCase(unittest.TestCase):
+    """A face glyph (S331) overlapping a hand glyph (S203). When they overlap,
+    relative order is preserved; when they don't, the canonical category order
+    (faces before hands) applies."""
+
+    def test_overlapping_hand_then_face_preserved(self):
+        self.assertEqual(
+            "M521x519S20310506x500S33100482x483",
+            canonicalize("M521x547S20310506x500S33100482x483"),
+        )
+
+    def test_overlapping_face_then_hand_preserved(self):
+        self.assertEqual(
+            "M521x519S33100482x483S20310506x500",
+            canonicalize("M521x547S33100482x483S20310506x500"),
+        )
+
+    def test_non_overlapping_reorders_to_category_order(self):
+        # Moving the face up (y 483 -> 443) breaks the overlap, so the canonical
+        # order kicks in and the face is written before the hand.
+        self.assertEqual(
+            "M521x515S33100482x443S20310506x500",
+            canonicalize("M521x547S20310506x500S33100482x443"),
+        )
+
+    def test_overlap_detection_is_glyph_not_box(self):
+        face = {"symbol": "S33100", "position": (482, 483)}
+        hand_touching = {"symbol": "S20310", "position": (506, 500)}
+        hand_clear = {"symbol": "S20310", "position": (506, 460)}
+        self.assertTrue(_symbols_share_ink(face, hand_touching))
+        self.assertFalse(_symbols_share_ink(face, hand_clear))
+
+    def test_order_matters_only_when_render_differs(self):
+        face = {"symbol": "S33100", "position": (482, 482)}
+        # S20310's white fill covers part of the face line, so order is visible.
+        hand_opaque = {"symbol": "S20310", "position": (506, 500)}
+        self.assertTrue(_order_matters(face, hand_opaque))
+        # S11511 overlaps the face but renders identically either way.
+        hand_transparent = {"symbol": "S11511", "position": (503, 500)}
+        self.assertTrue(_symbols_share_ink(face, hand_transparent))
+        self.assertFalse(_order_matters(face, hand_transparent))
+
+    def test_overlap_reordered_when_render_unaffected(self):
+        # S11511 (hand) overlaps S33100 (face) but order doesn't change the
+        # image, so the face is moved ahead of the hand into canonical order.
+        self.assertEqual(
+            "M544x527S33100482x482S11511503x500S20600522x495",
+            canonicalize("M544x527S11511503x500S33100482x482S20600522x495"),
+        )
+
+
+class CanonicalizeCategoryOrderCase(unittest.TestCase):
+    """Non-overlapping symbols sort by category (faces, other, hands, contact,
+    movement), then top-to-bottom, left-to-right."""
+
+    def test_category_order(self):
+        # One symbol per category, placed far apart so none overlap. Input is
+        # in reverse-canonical order; output must be face, other, hand,
+        # contact, movement.
+        fsw = "M750x750S26500250x250S20500300x300S10000350x350S37000400x400S33000450x450"
+        self.assertEqual(
+            "M499x487S33000450x450S37000400x400S10000350x350S20500300x300S26500250x250",
+            canonicalize(fsw),
+        )
+
+    def test_top_to_bottom_then_left_to_right_within_category(self):
+        # Three non-overlapping hands; canonical order is by y, then x.
+        fsw = "M540x540S10000510x510S10000260x510S10000510x260"
+        positions = [s["position"] for s in fsw_to_sign(canonicalize(fsw))["symbols"]]
+        self.assertEqual(sorted(positions, key=lambda p: (p[1], p[0])), positions)
+
+
+class CanonicalizeBoxCase(unittest.TestCase):
+
+    def test_box_is_tightened(self):
+        # The input box (547) is looser than the symbols require; it is
+        # recomputed to the tight bottom-right corner.
+        out = canonicalize("M521x547S20310506x500S33100482x483")
+        self.assertTrue(out.startswith("M521x519"))
+
+    def test_box_marker_preserved(self):
+        self.assertTrue(canonicalize("L521x547S20310506x500S33100482x483").startswith("L"))
+        self.assertTrue(canonicalize("R521x547S20310506x500S33100482x483").startswith("R"))
+
+
+class CanonicalizeContractCase(unittest.TestCase):
+
+    def test_empty_sign_passes_through(self):
+        self.assertEqual("M500x500", canonicalize("M500x500"))
+
+    def test_rejects_non_ascii(self):
+        with self.assertRaises(ValueError):
+            canonicalize("𝠃𝤛𝤵񍉡𝣴𝣵")
+
+    def test_is_idempotent(self):
+        for fsw in CORPUS_SIGNS:
+            with self.subTest(fsw=fsw):
+                once = canonicalize(fsw)
+                self.assertEqual(once, canonicalize(once))
+
+
+class CanonicalizeRenderEquivalenceCase(unittest.TestCase):
+    """Reordering only ever swaps symbols whose glyphs are disjoint, so the
+    rendered image is pixel-identical to the original (with the same box)."""
+
+    @staticmethod
+    def _render(fsw: str):
+        return np.array(signwriting_to_image(fsw, antialiasing=False, trust_box=False))
+
+    def test_render_unchanged(self):
+        for fsw in CORPUS_SIGNS:
+            with self.subTest(fsw=fsw):
+                original = self._render(fsw)
+                canonical = self._render(canonicalize(fsw))
+                self.assertEqual(original.shape, canonical.shape)
+                self.assertTrue(np.array_equal(original, canonical))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/signwriting/visualizer/visualize.py
+++ b/signwriting/visualizer/visualize.py
@@ -9,6 +9,7 @@ from signwriting.formats.fsw_to_sign import fsw_to_sign
 from signwriting.formats.fsw_to_swu import key2id, symbol_line, symbol_fill
 from signwriting.formats.swu import is_swu
 from signwriting.formats.swu_to_fsw import swu2fsw
+from signwriting.types import Sign
 
 # Type alias representing a tuple of four integers: Red, Green, Blue, Alpha
 RGBA = Tuple[int, int, int, int]
@@ -26,6 +27,18 @@ def get_symbol_size(symbol: str):
     line_id = symbol_line(key2id(symbol))
     left, top, right, bottom = font.getbbox(line_id)
     return right - left, bottom - top
+
+
+def signwriting_box(sign: Sign) -> Tuple[int, int]:
+    """Recompute a sign's bottom-right box corner ``(max_x, max_y)`` from its
+    symbols' rendered sizes - the tight box used when ``trust_box`` is off."""
+    max_x, max_y = 0, 0
+    for symbol in sign["symbols"]:
+        symbol_x, symbol_y = symbol["position"]
+        symbol_width, symbol_height = get_symbol_size(symbol["symbol"])
+        max_x = max(max_x, symbol_x + symbol_width)
+        max_y = max(max_y, symbol_y + symbol_height)
+    return max_x, max_y
 
 
 def _clear_caches_after_fork():
@@ -65,12 +78,7 @@ def signwriting_to_image(fsw: Union[str, List[str]], antialiasing=True, trust_bo
     max_x, max_y, = sign["box"]["position"]
 
     if not trust_box:
-        max_x, max_y = 0, 0
-        for symbol in sign['symbols']:
-            symbol_x, symbol_y = symbol["position"]
-            symbol_width, symbol_height = get_symbol_size(symbol["symbol"])
-            max_x = max(max_x, symbol_x + symbol_width)
-            max_y = max(max_y, symbol_y + symbol_height)
+        max_x, max_y = signwriting_box(sign)
 
     img = Image.new('RGBA', (max_x - min_x, max_y - min_y), (255, 255, 255, 0))
     draw = ImageDraw.Draw(img, 'RGBA')


### PR DESCRIPTION
## What

Adds `signwriting.utils.canonicalize`, which rewrites a single FSW sign into a canonical form:

```python
from signwriting.utils.canonicalize import canonicalize

canonicalize("M521x547S20310506x500S33100482x443")
# "M521x515S33100482x443S20310506x500"
```

It does three things:

1. **Orders symbols by category**, then top-to-bottom, left-to-right within a category. The category order — **faces → other → hands → contact → movement** — was derived empirically from the `single_signs` corpus (for every pair of categories, this is the dominant writing order, e.g. faces precede hands 69% of the time, hands precede movement 78%).

2. **Keeps an overlap only when its draw order is visible.** When two glyphs share an inked pixel, one is drawn on top of the other — but that only affects the image if the two paint a shared pixel with *different* colors (e.g. a hand's opaque white fill covering a face's line). Each overlapping pair is rendered both ways: if the images match, the pair sorts into canonical order; if they differ, it keeps its input order. As a result, `render(canonicalize(sign))` is pixel-identical to `render(sign)`.

3. **Tightens the box** to fit the symbols. This extracts the box recomputation from `signwriting_to_image` (its `trust_box=False` path) into a reusable `signwriting.visualizer.visualize.signwriting_box` helper.

`canonicalize` is idempotent and accepts ASCII FSW (convert SWU via `swu2fsw` first).

## Tests

`test_canonicalize.py` covers category ordering, within-category sorting, glyph-vs-box overlap detection, the render-both-ways order decision (harmless overlap reorders; fill-covering overlap doesn't), box tightening, box-marker preservation, empty/non-ASCII handling, idempotence, and a render-equivalence invariant across real corpus signs. Full suite passes; ruff + pylint clean.

See `signwriting/utils/canonicalize/README.md` for the algorithm and worked examples (with rendered images).