### PR TITLE
feat(canonicalize): center signs, matching signmaker's signNormalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ result_sign = join_signs_vertical(char_a, char_b)
 ```
 
 2. `canonicalize` rewrites a sign's symbols in a canonical order (by category,
-   then top-to-bottom, left-to-right) and tightens its box, without changing
-   the rendered image. See [`utils/canonicalize`](signwriting/utils/canonicalize/README.md).
+   then top-to-bottom, left-to-right), centers the sign, and tightens its box,
+   without changing the rendered image. See [`utils/canonicalize`](signwriting/utils/canonicalize/README.md).
 
 ```python
 from signwriting.utils.canonicalize import canonicalize
 
 canonicalize('M521x547S20310506x500S33100482x443')
-# M521x515S33100482x443S20310506x500
+# M521x554S33100482x482S20310506x539
 ```
 
 

--- a/signwriting/utils/canonicalize/README.md
+++ b/signwriting/utils/canonicalize/README.md
@@ -1,13 +1,13 @@
 # canonicalize
 
 Rewrite a single SignWriting sign so its symbols are listed in a canonical
-order and its box fits tightly.
+order, the sign is centered, and its box fits tightly.
 
 ```python
 from signwriting.utils.canonicalize import canonicalize
 
 canonicalize("M521x547S20310506x500S33100482x443")
-# "M521x515S33100482x443S20310506x500"
+# "M521x554S33100482x482S20310506x539"
 ```
 
 `canonicalize` accepts ASCII **Formal SignWriting (FSW)**. For SWU input,
@@ -43,15 +43,29 @@ convert first via `signwriting.formats.swu_to_fsw.swu2fsw`.
    constraints, and the canonical order is produced by a topological sort that
    honours them while otherwise following the category order above.
 
-3. **Tighten the box.** The box's bottom-right corner is recomputed from the
+3. **Center the sign.** The sign is translated so its center lands on
+   (500, 500). The pivot is the face/trunk when present, and the full bounding
+   box otherwise - a port of `@sutton-signwriting/font-ttf`'s `signNormalize`:
+
+   | Axis       | Pivot when present | Range       |
+   | ---------- | ------------------ | ----------- |
+   | horizontal | face               | `S2ff-S36c` |
+   | vertical   | face + trunk       | `S2ff-S375` |
+
+   So a sign with a face is centered horizontally on the face (the hands and
+   movements sit around it), matching how SignWriting anchors the body rather
+   than centering the whole drawing as a blob.
+
+4. **Tighten the box.** The box's bottom-right corner is recomputed from the
    symbols' rendered sizes (the same calculation `signwriting_to_image`
    performs with `trust_box=False`, exposed as
-   `signwriting.visualizer.visualize.signwriting_box`). The box marker
-   (`M`/`L`/`R`/`B`) is preserved.
+   `signwriting.visualizer.visualize.signwriting_box`) and shifted by the
+   centering offset. The box marker (`M`/`L`/`R`/`B`) is preserved.
 
 `canonicalize` is idempotent, and `render(canonicalize(sign))` is
-pixel-identical to `render(sign)` (with the same box), because two symbols are
-only ever reordered when swapping their draw order leaves the image unchanged.
+pixel-identical to `render(sign)` (cropped to its content): symbols are only
+reordered when swapping their draw order leaves the image unchanged, and
+centering is a uniform translation.
 
 ## Caveats
 
@@ -61,6 +75,10 @@ only ever reordered when swapping their draw order leaves the image unchanged.
   Antialiased rendering can blend glyph fringes that the 1-bit masks treat as
   disjoint, so the render-equivalence guarantee holds for non-antialiased
   rendering.
+* The centering *rule* matches signmaker's `signNormalize` exactly, but glyph
+  sizes are measured with this package's renderer (`get_symbol_size`) rather
+  than font-ttf's Chrome-canvas metrics, so centered coordinates can differ
+  from signmaker by ≤1px on some glyphs.
 
 ## Examples
 
@@ -72,8 +90,28 @@ padding).
 
 | Fix | Source | Target |
 | --- | --- | --- |
-| **Box too small.** The downward arrow (`S21b00` at y=582) falls below the stated box (`550`), so it renders clipped. The symbols are already in canonical order; only the box is tightened to `591`. | `M521x550S36d00479x450S1001c494x520S21b00500x582` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M521x550S36d00479x450S1001c494x520S21b00500x582&pad=10&size=2) | `M521x591S36d00479x450S1001c494x520S21b00500x582` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M521x591S36d00479x450S1001c494x520S21b00500x582&pad=10&size=2) |
-| **Order fixed, no overlap.** The face (`S32400`) is written after the hand (`S18500`), but faces come first. They don't overlap, so the face moves to the front; the image is unchanged. | `M563x553S18500536x495S32400482x483S29900549x521` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M563x553S18500536x495S32400482x483S29900549x521&pad=10&size=2) | `M563x553S32400482x483S18500536x495S29900549x521` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M563x553S32400482x483S18500536x495S29900549x521&pad=10&size=2) |
+| **Box too small.** The downward arrow (`S21b00` at y=582) falls below the stated box (`550`), so it renders clipped. The symbols are already in canonical order; the sign is re-centered and the box recomputed to fit, so the full arrow is shown. | `M521x550S36d00479x450S1001c494x520S21b00500x582` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M521x550S36d00479x450S1001c494x520S21b00500x582&pad=10&size=2) | `M521x639S36d00479x498S1001c494x568S21b00500x630` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M521x639S36d00479x498S1001c494x568S21b00500x630&pad=10&size=2) |
+| **Order fixed, no overlap.** The face (`S32400`) is written after the hand (`S18500`), but faces come first. They don't overlap, so the face moves to the front; the image is unchanged. | `M563x553S18500536x495S32400482x483S29900549x521` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M563x553S18500536x495S32400482x483S29900549x521&pad=10&size=2) | `M563x552S32400482x482S18500536x494S29900549x520` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M563x552S32400482x482S18500536x494S29900549x520&pad=10&size=2) |
 | **Order fixed despite overlap.** The face (`S33100`) overlaps the hand (`S11511`), but the hand has no fill there, so rendering both orders is identical - the face can safely move to the front. | `M544x527S11511503x500S33100482x482S20600522x495` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M544x527S11511503x500S33100482x482S20600522x495&pad=10&size=2) | `M544x527S33100482x482S11511503x500S20600522x495` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M544x527S33100482x482S11511503x500S20600522x495&pad=10&size=2) |
 | **Order fixed despite overlap.** The eyebrow (`S30a00`) overlaps the hand (`S10000`), but again neither covers the other, so the rendered image is unaffected and the face is written first. | `M518x529S10000469x499S30a00482x482` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M518x529S10000469x499S30a00482x482&pad=10&size=2) | `M518x529S30a00482x482S10000469x499` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M518x529S30a00482x482S10000469x499&pad=10&size=2) |
 | **Order can't be fixed.** Two hands (`S10010`, `S15d59`) overlap, and the right one's opaque white fill covers the left one's lines - rendering the two orders gives different images, so the input order is kept. We'd normally write the top-left hand (`S15d59`) first, but here it has to come second. | `M515x516S10010500x486S15d59485x484` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M515x516S10010500x486S15d59485x484&pad=10&size=2) | `M515x516S10010500x486S15d59485x484` <br> ![](https://www.signbank.org/signpuddle2.0/glyphogram.php?text=M515x516S10010500x486S15d59485x484&pad=10&size=2) |
+
+### Centering
+
+Centering is a uniform translation, so it never changes the rendered image -
+its job is to give every equivalent sign one set of coordinates. The same sign
+drawn at two different offsets normalizes to a single form:
+
+```python
+canonicalize("M544x527S11511503x500S33100482x482S20600522x495")  # as authored
+canonicalize("M564x547S11511523x520S33100502x502S20600542x515")  # shifted +20,+20
+# both -> "M544x527S33100482x482S11511503x500S20600522x495"
+```
+
+With a face present, the horizontal pivot is the face, not the whole drawing -
+so the face's midpoint lands on `x=500` regardless of where the hands reach:
+
+```python
+canonicalize("M620x540S33000482x460S10000600x500")
+# "M609x552S33000476x482S10000594x522"  (face S33000 centered on x=500)
+```

--- a/signwriting/utils/canonicalize/canonicalize.py
+++ b/signwriting/utils/canonicalize/canonicalize.py
@@ -47,6 +47,35 @@ def _sort_key(symbol: SignSymbol):
     return _category_rank(symbol["symbol"]), y, x
 
 
+# A sign's center pivot, ported from @sutton-signwriting/font-ttf signNormalize:
+# when a sign contains a face it is centered horizontally on the face, when it
+# contains a face or trunk it is centered vertically on those, and otherwise it
+# falls back to the full bounding box.
+_HCENTER_RANGE = (0x2ff, 0x36c)  # head / face
+_VCENTER_RANGE = (0x2ff, 0x375)  # head / face + trunk
+
+
+def _bbox(symbols: List[SignSymbol]):
+    left = min(s["position"][0] for s in symbols)
+    top = min(s["position"][1] for s in symbols)
+    right = max(s["position"][0] + get_symbol_size(s["symbol"])[0] for s in symbols)
+    bottom = max(s["position"][1] + get_symbol_size(s["symbol"])[1] for s in symbols)
+    return left, top, right, bottom
+
+
+def _center_offset(symbols: List[SignSymbol]):
+    """Offset of the sign's center from (500, 500), using the face/trunk pivot
+    when present and the full bounding box otherwise."""
+    left, top, right, bottom = _bbox(symbols)
+    faces = [s for s in symbols if _HCENTER_RANGE[0] <= int(s["symbol"][1:4], 16) <= _HCENTER_RANGE[1]]
+    if faces:
+        left, _, right, _ = _bbox(faces)
+    bodies = [s for s in symbols if _VCENTER_RANGE[0] <= int(s["symbol"][1:4], 16) <= _VCENTER_RANGE[1]]
+    if bodies:
+        _, top, _, bottom = _bbox(bodies)
+    return int((left + right) / 2) - 500, int((top + bottom) / 2) - 500
+
+
 @functools.cache
 def _symbol_mask(symbol: str) -> np.ndarray:
     """Boolean ink mask (line + fill) of a symbol rendered at the origin."""
@@ -144,11 +173,14 @@ def _canonical_order(symbols: List[SignSymbol]) -> List[SignSymbol]:
 
 
 def canonicalize(fsw: str) -> str:
-    """Rewrite an FSW sign with its symbols in canonical order and a tight box.
+    """Rewrite an FSW sign with its symbols in canonical order, centered, with a
+    tight box.
 
     Symbols are ordered by category (faces, other, hands, contact, movement)
     and within a category top-to-bottom then left-to-right; overlapping symbols
-    keep their original relative order so the rendered image is unchanged.
+    keep their original relative order so the rendered image is unchanged. The
+    sign is then centered on (500, 500) - on its face/trunk when present,
+    otherwise on its bounding box - and the box recomputed to fit tightly.
 
     ``fsw`` must be ASCII Formal SignWriting. For SWU input, convert with
     ``signwriting.formats.swu_to_fsw.swu2fsw`` first.
@@ -160,8 +192,13 @@ def canonicalize(fsw: str) -> str:
     if not sign["symbols"]:
         return fsw
 
+    ordered = _canonical_order(sign["symbols"])
+    max_x, max_y = signwriting_box(sign)
+    offset_x, offset_y = _center_offset(ordered)
     canonical_sign: Sign = {
-        "box": {"symbol": sign["box"]["symbol"], "position": signwriting_box(sign)},
-        "symbols": _canonical_order(sign["symbols"]),
+        "box": {"symbol": sign["box"]["symbol"], "position": (max_x - offset_x, max_y - offset_y)},
+        "symbols": [{"symbol": s["symbol"],
+                     "position": (s["position"][0] - offset_x, s["position"][1] - offset_y)}
+                    for s in ordered],
     }
     return sign_to_fsw(canonical_sign)

--- a/signwriting/utils/canonicalize/test_canonicalize.py
+++ b/signwriting/utils/canonicalize/test_canonicalize.py
@@ -5,7 +5,7 @@ import numpy as np
 from signwriting.formats.fsw_to_sign import fsw_to_sign
 from signwriting.utils.canonicalize import canonicalize
 from signwriting.utils.canonicalize.canonicalize import _order_matters, _symbols_share_ink
-from signwriting.visualizer.visualize import signwriting_to_image
+from signwriting.visualizer.visualize import get_symbol_size, signwriting_to_image
 
 # Real signs from the single_signs corpus, spanning a range of symbol counts
 # and categories. Canonicalization must never change the rendered image.
@@ -38,13 +38,13 @@ class CanonicalizeOverlapCase(unittest.TestCase):
 
     def test_overlapping_hand_then_face_preserved(self):
         self.assertEqual(
-            "M521x519S20310506x500S33100482x483",
+            "M521x518S20310506x499S33100482x482",
             canonicalize("M521x547S20310506x500S33100482x483"),
         )
 
     def test_overlapping_face_then_hand_preserved(self):
         self.assertEqual(
-            "M521x519S33100482x483S20310506x500",
+            "M521x518S33100482x482S20310506x499",
             canonicalize("M521x547S33100482x483S20310506x500"),
         )
 
@@ -52,7 +52,7 @@ class CanonicalizeOverlapCase(unittest.TestCase):
         # Moving the face up (y 483 -> 443) breaks the overlap, so the canonical
         # order kicks in and the face is written before the hand.
         self.assertEqual(
-            "M521x515S33100482x443S20310506x500",
+            "M521x554S33100482x482S20310506x539",
             canonicalize("M521x547S20310506x500S33100482x443"),
         )
 
@@ -92,7 +92,7 @@ class CanonicalizeCategoryOrderCase(unittest.TestCase):
         # contact, movement.
         fsw = "M750x750S26500250x250S20500300x300S10000350x350S37000400x400S33000450x450"
         self.assertEqual(
-            "M499x487S33000450x450S37000400x400S10000350x350S20500300x300S26500250x250",
+            "M525x544S33000476x507S37000426x457S10000376x407S20500326x357S26500276x307",
             canonicalize(fsw),
         )
 
@@ -107,13 +107,35 @@ class CanonicalizeBoxCase(unittest.TestCase):
 
     def test_box_is_tightened(self):
         # The input box (547) is looser than the symbols require; it is
-        # recomputed to the tight bottom-right corner.
+        # recomputed to the tight bottom-right corner (and the sign centered).
         out = canonicalize("M521x547S20310506x500S33100482x483")
-        self.assertTrue(out.startswith("M521x519"))
+        self.assertTrue(out.startswith("M521x518"))
 
     def test_box_marker_preserved(self):
         self.assertTrue(canonicalize("L521x547S20310506x500S33100482x483").startswith("L"))
         self.assertTrue(canonicalize("R521x547S20310506x500S33100482x483").startswith("R"))
+
+
+class CanonicalizeCenterCase(unittest.TestCase):
+    """Centering ported from @sutton-signwriting/font-ttf signNormalize: a sign
+    is moved so its center sits on (500, 500), pivoting on the face/trunk when
+    present and the full bounding box otherwise."""
+
+    def test_centers_horizontally_on_face(self):
+        # Face plus a hand far to the right. Horizontal centering pivots on the
+        # face (S2ff-S36c), so the face's midpoint lands on 500 - independent of
+        # where the hand sits.
+        out = canonicalize("M620x540S33000482x460S10000600x500")
+        face = next(s for s in fsw_to_sign(out)["symbols"] if s["symbol"] == "S33000")
+        left = face["position"][0]
+        right = left + get_symbol_size("S33000")[0]
+        self.assertEqual(500, int((left + right) / 2))
+
+    def test_normalizes_translation(self):
+        # The same sign shifted by a constant offset normalizes to one form.
+        base = "M544x527S11511503x500S33100482x482S20600522x495"
+        shifted = "M564x547S11511523x520S33100502x502S20600542x515"
+        self.assertEqual(canonicalize(base), canonicalize(shifted))
 
 
 class CanonicalizeContractCase(unittest.TestCase):
@@ -133,8 +155,9 @@ class CanonicalizeContractCase(unittest.TestCase):
 
 
 class CanonicalizeRenderEquivalenceCase(unittest.TestCase):
-    """Reordering only ever swaps symbols whose glyphs are disjoint, so the
-    rendered image is pixel-identical to the original (with the same box)."""
+    """Reordering only swaps symbols whose draw order is invisible, and
+    centering is a uniform translation, so the rendered image (cropped to its
+    content) is pixel-identical to the original."""
 
     @staticmethod
     def _render(fsw: str):


### PR DESCRIPTION
## What

Extends `canonicalize` to **center** the sign, ported from signmaker's `center` action (`@sutton-signwriting/font-ttf` `signNormalize`).

After ordering symbols and resolving overlaps, the sign is translated so its **center lands on (500, 500)**. The pivot is the face/trunk when present, and the full bounding box otherwise:

| Axis | Pivot when present | Range |
| --- | --- | --- |
| horizontal | face | `S2ff–S36c` |
| vertical | face + trunk | `S2ff–S375` |

So a sign with a face is centered horizontally **on the face** (hands/movements sit around it), matching how SignWriting anchors the body — rather than centering the whole drawing as a blob. The box is recomputed and shifted by the same offset.

```python
canonicalize("M620x540S33000482x460S10000600x500")
# "M609x552S33000476x482S10000594x522"  (face S33000 centered on x=500, despite the hand far right)
```

## Properties preserved

- **Idempotent** — once centered, the offset is 0.
- **Render-equivalent** — centering is a uniform translation, so `render(canonicalize(sign))` is still pixel-identical to `render(sign)` (cropped to content). Two copies of a sign at different offsets normalize to one form.

## Note on exactness

The centering **rule** (the hcenter/vcenter pivot) matches signmaker 1:1 — verified against font-ttf's documented `signNormalize` example, which our port reproduces. Glyph **sizes**, however, come from this package's `get_symbol_size` (used everywhere else in `canonicalize` and the visualizer) rather than font-ttf's Chrome-canvas metrics, so centered coordinates can differ from signmaker by ≤1px on some glyphs. Replicating font-ttf's exact metrics would require its browser-canvas measurement; this is documented in the module README caveats.

## Tests

Adds a `CanonicalizeCenterCase` (face-pivot centering + translation normalization), updates the shifted expectations in existing cases, and keeps the idempotence + render-equivalence invariants green across the corpus signs. Full suite passes (121); ruff + pylint clean. README updated with the centering algorithm step and a worked example.