### PR TITLE
fix(packaging): discover subpackages automatically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,17 +47,10 @@ disable = [
 ]
 good-names = ["i", "f", "x", "y"]
 
-[tool.setuptools]
-packages = [
-    "signwriting",
-    "signwriting.formats",
-    "signwriting.tokenizer",
-    "signwriting.utils",
-    "signwriting.utils.mirror",
-    "signwriting.visualizer",
-    "signwriting.fingerspelling",
-    "signwriting.mouthing"
-]
+# Discover every signwriting subpackage automatically so new ones (e.g.
+# utils/canonicalize) ship without being listed here by hand.
+[tool.setuptools.packages.find]
+include = ["signwriting*"]
 
 [tool.setuptools.package-data]
 signwriting = ["**/*.ttf", "**/*.txt", "**/*.json"]


### PR DESCRIPTION
## Problem

Reported by Shaltiel: after a plain `pip install` (non-editable), `from signwriting.utils.canonicalize import canonicalize` raises `ModuleNotFoundError`. It only works with `pip install -e`.

## Cause

`[tool.setuptools].packages` was an **explicit hand-maintained list** that never had `signwriting.utils.canonicalize` added. Editable installs link the source tree (so they ignore the list and work), but built wheels only contain the listed packages — so the published **v0.1.10 wheel is missing `canonicalize`**.

The list had also silently dropped three other real packages: `signwriting.hamnosys`, `signwriting.primitives`, and `signwriting.primitives.ase`.

## Fix

Switch to setuptools **automatic discovery** so the list never goes stale again:

```toml
[tool.setuptools.packages.find]
include = ["signwriting*"]
```

Verified by building the wheel and inspecting it — it now contains all 12 packages (including `canonicalize` + the three previously-missing ones) and all 52 data files. The `tokenizer/graph` example dir has no `__init__.py` and is correctly excluded.

## Follow-up

The published **v0.1.10 on PyPI is broken** (missing `canonicalize`). After this merges, a patch release (**v0.1.11**) is needed to ship a correct wheel.