### PR TITLE
fix(canonicalize): canonicalize each sign independently

### DIFF
--- a/signwriting/utils/canonicalize/README.md
+++ b/signwriting/utils/canonicalize/README.md
@@ -13,6 +13,14 @@ canonicalize("M521x547S20310506x500S33100482x443")
 `canonicalize` accepts ASCII **Formal SignWriting (FSW)**. For SWU input,
 convert first via `signwriting.formats.swu_to_fsw.swu2fsw`.
 
+A string may hold several whitespace-separated signs; each is canonicalized
+independently and the results are re-joined with a single space.
+
+```python
+canonicalize("M524x520S15a11501x497S20600487x479 M507x507S1f720487x492")
+# "M519x521S15a11496x498S20600482x480 M510x508S1f720490x493"
+```
+
 ## Algorithm
 
 1. **Order by category.** Each symbol belongs to one ISWA category, sorted in

--- a/signwriting/utils/canonicalize/canonicalize.py
+++ b/signwriting/utils/canonicalize/canonicalize.py
@@ -172,22 +172,7 @@ def _canonical_order(symbols: List[SignSymbol]) -> List[SignSymbol]:
     return order
 
 
-def canonicalize(fsw: str) -> str:
-    """Rewrite an FSW sign with its symbols in canonical order, centered, with a
-    tight box.
-
-    Symbols are ordered by category (faces, other, hands, contact, movement)
-    and within a category top-to-bottom then left-to-right; overlapping symbols
-    keep their original relative order so the rendered image is unchanged. The
-    sign is then centered on (500, 500) - on its face/trunk when present,
-    otherwise on its bounding box - and the box recomputed to fit tightly.
-
-    ``fsw`` must be ASCII Formal SignWriting. For SWU input, convert with
-    ``signwriting.formats.swu_to_fsw.swu2fsw`` first.
-    """
-    if not fsw.isascii():
-        raise ValueError("canonicalize expects ASCII FSW; convert SWU input via swu2fsw first")
-
+def _canonicalize_sign(fsw: str) -> str:
     sign = fsw_to_sign(fsw)
     if not sign["symbols"]:
         return fsw
@@ -202,3 +187,26 @@ def canonicalize(fsw: str) -> str:
                     for s in ordered],
     }
     return sign_to_fsw(canonical_sign)
+
+
+def canonicalize(fsw: str) -> str:
+    """Rewrite each FSW sign with its symbols in canonical order, centered, with
+    a tight box.
+
+    Symbols are ordered by category (faces, other, hands, contact, movement)
+    and within a category top-to-bottom then left-to-right; overlapping symbols
+    keep their original relative order so the rendered image is unchanged. Each
+    sign is then centered on (500, 500) - on its face/trunk when present,
+    otherwise on its bounding box - and the box recomputed to fit tightly.
+
+    ``fsw`` may hold multiple whitespace-separated signs; each is canonicalized
+    independently (``fsw_to_sign`` greedily absorbs every symbol into the first
+    box, so treating the whole string as one sign would merge them).
+
+    ``fsw`` must be ASCII Formal SignWriting. For SWU input, convert with
+    ``signwriting.formats.swu_to_fsw.swu2fsw`` first.
+    """
+    if not fsw.isascii():
+        raise ValueError("canonicalize expects ASCII FSW; convert SWU input via swu2fsw first")
+
+    return " ".join(_canonicalize_sign(sign) for sign in fsw.split())

--- a/signwriting/utils/canonicalize/test_canonicalize.py
+++ b/signwriting/utils/canonicalize/test_canonicalize.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 
 import numpy as np
@@ -152,6 +153,28 @@ class CanonicalizeContractCase(unittest.TestCase):
             with self.subTest(fsw=fsw):
                 once = canonicalize(fsw)
                 self.assertEqual(once, canonicalize(once))
+
+
+class CanonicalizeMultiSignCase(unittest.TestCase):
+    """``fsw_to_sign`` absorbs every symbol into the first box, so a whitespace-
+    separated multi-sign string must be canonicalized one sign at a time rather
+    than merged into a single box."""
+
+    def test_each_sign_canonicalized_independently(self):
+        first = "M532x585S30004482x483S1ce02487x518S1ce0a477x533S20500522x508S2eb34512x543S2eb10472x553"
+        second = "M522x527S20300497x512S20320507x507S21400479x514S28a02484x474S20e00494x494"
+        out = canonicalize(f"{first} {second}")
+        self.assertEqual(f"{canonicalize(first)} {canonicalize(second)}", out)
+
+    def test_signs_are_not_merged(self):
+        first = "M532x585S30004482x483S1ce02487x518S1ce0a477x533S20500522x508S2eb34512x543S2eb10472x553"
+        second = "M522x527S20300497x512S20320507x507S21400479x514S28a02484x474S20e00494x494"
+        out = canonicalize(f"{first} {second}")
+        self.assertEqual(2, len(out.split()))
+        self.assertEqual(2, len(re.findall(r"[MLRB]\d{3}x\d{3}", out)))
+
+    def test_whitespace_only_is_empty(self):
+        self.assertEqual("", canonicalize("   "))
 
 
 class CanonicalizeRenderEquivalenceCase(unittest.TestCase):


### PR DESCRIPTION
## Problem

`canonicalize` silently **merged** multiple signs into one. Given a whitespace-separated multi-sign FSW string, `fsw_to_sign` takes the *first* box marker and greedily absorbs every following symbol — ignoring the later boxes — so all signs collapsed into a single box and were re-ordered/centered together.

This corrupted multi-sign references (e.g. training targets): a two-sign row `M…(6 symbols) M…(5 symbols)` became one `M…` box with all 11 symbols jammed into the first sign's coordinate space. The expected "raises on multi-sign" fallback never triggered — it succeeded and produced garbage.

## Fix

Split the input on whitespace and canonicalize each sign independently, re-joining with a single space:

```python
return " ".join(_canonicalize_sign(sign) for sign in fsw.split())
```

A single FSW sign contains no spaces (the optional `A…` sequence prefix, box, and spatial symbols are one token), so whitespace cleanly separates signs. Single-sign input is unchanged.

## Tests

Adds `CanonicalizeMultiSignCase`: each sign is canonicalized independently, the output keeps two box markers (not merged), and whitespace-only input returns empty. Full suite passes (19 in the module); ruff + pylint clean. README documents the multi-sign behavior with an example.